### PR TITLE
Fixes getting of items when state is not given

### DIFF
--- a/lib/pocketeer/get.ex
+++ b/lib/pocketeer/get.ex
@@ -32,7 +32,7 @@ defmodule Pocketeer.Get do
     offset:      offset
   }
 
-  defstruct state: :unread,
+  defstruct state: nil,
             favorite: nil,
             tag: nil,
             contentType: nil,


### PR DESCRIPTION
The default state was set to `unread` when not set as option, leading to wrong results in combination with favourited items.