### PR TITLE
Remove unsupported build from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ elixir:
   - 1.2.5
   - 1.3.1
 otp_release:
-  - 17.5
   - 18.3
   - 19.0
 sudo: false # to use faster container based build environment

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pocketeer
 
-![alt tag](https://travis-ci.org/justahero/pocketeer.svg?branch=master)
+[![Build Status](https://travis-ci.org/justahero/pocketeer.svg?branch=master)](https://travis-ci.org/justahero/pocketeer)
 
 A client library for the [getpocket.com](https://getpocket.com) service written in Elixir. The library supports all endpoints of the Pocket API. It also supports modifying mulitple items in a bulk operation.
 


### PR DESCRIPTION
OTP release 17.5 is not supported by Elixir 1.2.5, therefore the build is removed from the Travis configuration.